### PR TITLE
mainPage의 리팩토링과 chatPage 오류 해결 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "axios": "^1.8.4",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "framer-motion": "^12.6.3",
+        "framer-motion": "^12.9.1",
         "gsap": "^3.12.7",
         "lenis": "^1.2.3",
         "lucide-react": "^0.487.0",
@@ -8780,13 +8780,13 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "12.6.3",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.6.3.tgz",
-      "integrity": "sha512-2hsqknz23aloK85bzMc9nSR2/JP+fValQ459ZTVElFQ0xgwR2YqNjYSuDZdFBPOwVCt4Q9jgyTt6hg6sVOALzw==",
+      "version": "12.9.1",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.9.1.tgz",
+      "integrity": "sha512-dZBp2TO0a39Cc24opshlLoM0/OdTZVKzcXWuhntfwy2Qgz3t9+N4sTyUqNANyHaRFiJUWbwwsXeDvQkEBPky+g==",
       "license": "MIT",
       "dependencies": {
-        "motion-dom": "^12.6.3",
-        "motion-utils": "^12.6.3",
+        "motion-dom": "^12.9.1",
+        "motion-utils": "^12.8.3",
         "tslib": "^2.4.0"
       },
       "peerDependencies": {
@@ -10824,18 +10824,18 @@
       }
     },
     "node_modules/motion-dom": {
-      "version": "12.6.3",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.6.3.tgz",
-      "integrity": "sha512-gRY08RjcnzgFYLemUZ1lo/e9RkBxR+6d4BRvoeZDSeArG4XQXERSPapKl3LNQRu22Sndjf1h+iavgY0O4NrYqA==",
+      "version": "12.9.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.9.1.tgz",
+      "integrity": "sha512-xqXEwRLDYDTzOgXobSoWtytRtGlf7zdkRfFbrrdP7eojaGQZ5Go4OOKtgnx7uF8sAkfr1ZjMvbCJSCIT2h6fkQ==",
       "license": "MIT",
       "dependencies": {
-        "motion-utils": "^12.6.3"
+        "motion-utils": "^12.8.3"
       }
     },
     "node_modules/motion-utils": {
-      "version": "12.6.3",
-      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.6.3.tgz",
-      "integrity": "sha512-R/b3Ia2VxtTNZ4LTEO5pKYau1OUNHOuUfxuP0WFCTDYdHkeTBR9UtxR1cc8mDmKr8PEhmmfnTKGz3rSMjNRoRg==",
+      "version": "12.8.3",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.8.3.tgz",
+      "integrity": "sha512-GYVauZEbca8/zOhEiYOY9/uJeedYQld6co/GJFKOy//0c/4lDqk0zB549sBYqqV2iMuX+uHrY1E5zd8A2L+1Lw==",
       "license": "MIT"
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "axios": "^1.8.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "framer-motion": "^12.6.3",
+    "framer-motion": "^12.9.1",
     "gsap": "^3.12.7",
     "lenis": "^1.2.3",
     "lucide-react": "^0.487.0",

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -20,6 +20,7 @@ export default function Page() {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [isFormSubmitted, setIsFormSubmitted] = useState(false);
   const [isComposing, setIsComposing] = useState(false); // 한글 입력 여부
+  const [uuid, setUuid] = useState<string | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -29,17 +30,14 @@ export default function Page() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const handleFormSubmit = async (formData: UserFormData) => {
-    const userMessage = `${formData.email}\n${formData.username}`;
-    
   useEffect(() => {
     if (scrollRef.current) {
       scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
     }
   }, [messages]); 
 
-  const handleChatSubmit = () => {
-    if (chatInput.trim() === '') return;
+  const handleFormSubmit = async (formData: UserFormData) => {
+    const userMessage = `${formData.email}\n${formData.username}`;
     setMessages((prev) => [
       ...prev,
       { text: userMessage, sender: 'user' },
@@ -65,6 +63,7 @@ export default function Page() {
       ]);
     }
   };
+    
 
   const handleChatSubmit = async () => {
     if (chatInput.trim() === '') return;
@@ -152,3 +151,4 @@ export default function Page() {
     </div>
   );
 }
+

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -64,6 +64,21 @@ export default function Page() {
     }
   };
     
+  useEffect(() => {
+    const scrollContainer = scrollRef.current;
+    
+    const handleWheel = (e: WheelEvent) => {
+      e.stopPropagation();
+    };
+    
+    if (scrollContainer) {
+      scrollContainer.addEventListener('wheel', handleWheel, { passive: false });
+      return () => {
+        scrollContainer.removeEventListener('wheel', handleWheel);
+      };
+    }
+  }, []);
+
 
   const handleChatSubmit = async () => {
     if (chatInput.trim() === '') return;
@@ -120,6 +135,7 @@ export default function Page() {
       <div
         ref={scrollRef}
         className="flex-1 overflow-y-auto p-4 bg-sky-100 flex flex-col gap-2 dark:bg-black"
+        
       >
         {messages.map((msg, idx) => (
           <Input

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,19 +1,30 @@
+import RotateSection from '@/components/product/main/RotateSection';
 import TextSection from '@/components/product/main/TextSeciton';
 import ImageSection from '@/components/product/main/ImageSection';
 import LinkSection from '@/components/product/main/LinkSection';
-import RotateSection from '@/components/product/main/RotateSection';
+import SectionWrapper from '@/components/product/main/SectionWrapper';
 import FloatingButton from '@/components/common/FloatingButton';
 
 export default function Home() {
   return (
-    <>
-      <main className="bg-white dark:bg-black">
+    <main className="bg-white dark:bg-black overflow-hidden">
+      <SectionWrapper direction="right">
         <RotateSection />
-        <TextSection key="hero" />
-        <ImageSection key="main" />
-        <LinkSection key="link" />
-        <FloatingButton />
-      </main>
-    </>
+      </SectionWrapper>
+
+      <SectionWrapper direction="left">
+        <TextSection />
+      </SectionWrapper>
+
+      <SectionWrapper direction="right">
+        <ImageSection />
+      </SectionWrapper>
+
+      <SectionWrapper direction="up">
+        <LinkSection />
+      </SectionWrapper>
+
+      <FloatingButton />
+    </main>
   );
 }

--- a/src/components/common/Button/index.tsx
+++ b/src/components/common/Button/index.tsx
@@ -32,7 +32,7 @@ export default function Button({
           <button
             type='button'
             onClick={onSubmit}
-            className='flex items-center justify-center border bg-amber-300 text-black p-2 rounded-md'
+            className='flex items-center justify-center border bg-amber-300 text-black p-2 rounded-md hover:bg-blue-600'
             disabled={disabled}
           >
             {value}

--- a/src/components/product/chat/chatform.tsx
+++ b/src/components/product/chat/chatform.tsx
@@ -49,12 +49,12 @@ export default function ChatForm({ onSubmitComplete }: ChatFormProps) {
 
       <Input
         type="text"
-        value={name}
+        value={username}
         placeholder="이름"
-        onChange={(val) => setValue('name', val, { shouldValidate: true })}
+        onChange={(val) => setValue('username', val, { shouldValidate: true })}
       />
 
-      <h1>2. 이름</h1>
+      <h1>2. 이메일</h1>
       <Input
         type="text"
         value={email}

--- a/src/components/product/main/ImageSection.tsx
+++ b/src/components/product/main/ImageSection.tsx
@@ -13,7 +13,7 @@ export default function MainSection() {
         <div
           key={card.id}
           className={`relative m-2 flex flex-col justify-end bg-cover bg-center rounded-lg shadow-lg cursor-pointer transition-all duration-500 ${
-            activeIndex === index ? 'w-80 h-96' : 'w-40 h-60'
+            activeIndex === index ? 'w-70 h-48 md:w-80 md:h-96' : 'w-10 h-20 md:w-40 md:h-60'
           }`}
           style={{ backgroundImage: `url(${card.image})` }}
           onClick={() => setActiveIndex(index)}
@@ -23,8 +23,6 @@ export default function MainSection() {
             <div className="flex items-center space-x-2">
               <i className={`${card.icon} text-xl`}></i>
               <div>
-                <h3 className="text-lg font-bold">{card.title}</h3>
-                <p className="text-sm">{card.subtitle}</p>
               </div>
             </div>
           </div>

--- a/src/components/product/main/RotateSection.tsx
+++ b/src/components/product/main/RotateSection.tsx
@@ -109,9 +109,9 @@ export default function RotateSection() {
   }, []);
 
   return (
-    <section className="relative w-full h-screen overflow-hidden text-black">
-      <div className="absolute top-[28%] left-1/2 -translate-x-1/2 h-screen select-none flex flex-col gap-10">
-        <p className="text-5xl font-bold text-transparent bg-gradient-to-r from-orange-400 via-orange-500 to-orange-600 bg-clip-text shadow-lg">
+    <section className="relative w-full h-screen overflow-hidden text-black ">
+      <div className="absolute top-[14%] left-1/2 -translate-x-1/2 h-screen select-none flex flex-col gap-20">
+        <p className="md:text-5xl text-2xl font-bold text-transparent bg-gradient-to-r from-orange-400 via-orange-500 to-orange-600 bg-clip-text shadow-lg">
           CareerBot 
         </p>
 
@@ -125,7 +125,7 @@ export default function RotateSection() {
               key={idx}
               className="item absolute left-1/2 top-0 transform -translate-x-1/2 cursor-pointer select-none"
             >
-              <div className="card border-[10px] border-black rounded-[17px] overflow-hidden cursor-grab relative w-[430px] h-[610px] sm:w-[350px] sm:h-[497px] max-h-[90vh]">
+              <div className="card border-[10px] border-black dark:border-white rounded-[17px] overflow-hidden cursor-grab relative w-[300px] h-[300px] sm:w-[350px] sm:h-[497px] max-h-[90vh]">
                 <Image
                   src={src}
                   alt={`rotating-${idx}`}

--- a/src/components/product/main/SectionWrapper.tsx
+++ b/src/components/product/main/SectionWrapper.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { ReactNode, useRef } from 'react';
+import { motion, useScroll, useTransform } from 'framer-motion';
+
+type SectionWrapperProps = {
+    children: ReactNode;
+    direction?: 'left' | 'right' | 'up' | 'down';
+  };
+
+export default function SectionWrapper({ children, direction = 'left' }: SectionWrapperProps) {
+  const sectionRef = useRef(null);
+
+  const { scrollYProgress } = useScroll({
+    target: sectionRef,
+    offset: ['start end', 'end start'],
+  });
+
+  const x = useTransform(
+    scrollYProgress,
+    [0, 0.25, 0.5, 0.75, 1],
+    direction === 'left'
+      ? [0, 0, 0, 100, 300]
+      : direction === 'right'
+      ? [0, 0, 0, -100, -300]
+      : [0, 0, 0, 0, 0]
+  );
+
+  const y = useTransform(
+    scrollYProgress,
+    [0, 0.25, 0.5, 0.75, 1],
+    direction === 'up'
+      ? [0, 0, 0, -100, -300]
+      : direction === 'down'
+      ? [0, 0, 0, 100, 300]
+      : [0, 0, 0, 0, 0]
+  );
+
+  const opacity = useTransform(scrollYProgress, [0, 0.25, 0.6, 0.8, 1], [1, 1, 1, 0.5, 0]);
+  const scale = useTransform(scrollYProgress, [0, 0.25, 0.5, 0.75, 1], [1, 1, 1, 0.95, 0.9]);
+
+  return (
+    <motion.div
+      ref={sectionRef}
+      style={{ x, y, opacity, scale }}
+      className="min-h-screen flex items-center justify-center"
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/src/components/product/main/TextSeciton.tsx
+++ b/src/components/product/main/TextSeciton.tsx
@@ -5,7 +5,7 @@ import { Preview } from '@/components/ui/demo';
 
 export default function TextSection() {
   return (
-    <motion.section className="relative z-10 min-h-screen flex items-center justify-center">
+    <motion.section className="relative z-10 h-70 md:min-h-screen flex items-center justify-center">
       <Preview />
     </motion.section>
   );

--- a/src/components/ui/demo.tsx
+++ b/src/components/ui/demo.tsx
@@ -11,7 +11,7 @@ function Preview() {
       <LayoutGroup>
         <motion.div className="flex whitespace-pre flex-col gap-10 items-center" layout>
           <motion.span
-            className="pt-0.5 sm:pt-1 md:pt-2 text-[#f89b00] text-6xl"
+            className="pt-0.5 sm:pt-1 md:pt-2 text-[#f89b00] text-2xl xl:text-6xl md:text-4xl"
             layout
             transition={{ type: "spring", damping: 30, stiffness: 400 }}
           >
@@ -25,7 +25,7 @@ function Preview() {
               "공부하는 방법을",
               "취업하는 방법을",
             ]}
-            mainClassName="text-[#1a237e] text- px-2 sm:px-2 md:px-3 bg-[#f89b00] overflow-hidden py-0.5 sm:py-1 md:py-2 justify-center rounded-lg"
+            mainClassName=" text-[#1a237e] text- px-2 sm:px-2 md:px-3 text-xl md:text-4xl bg-[#f89b00] overflow-hidden py-0.5 sm:py-1 md:py-2 justify-center rounded-lg"
             staggerFrom={"last"}
             initial={{ y: "100%" }}
             animate={{ y: 0 }}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -11,6 +11,7 @@
   font-display: swap;
 }
 
+
 :root {
   --font-primary: '87mmilsang';
   --radius: 0.625rem;


### PR DESCRIPTION
## #️⃣연관된 이슈(이슈번호와 연동)

close #54 

## 📝작업 내용(작업한 내용을 간략히 설명)

- chatPage의 error 해결 (충돌 해결 시에 코드가 지워지고 중복이 됐었음)
- chatPage에 휠 이벤트 리스너 추가로 스크롤 안되는 문제를 해결
- mainPage의 반응형 디자인 고려
- mainPage 섹션 날라가는 애니메이션 추가 



## 스크린샷 

- 모바일 규격 
<img width="326" alt="스크린샷 2025-04-25 오전 10 34 17" src="https://github.com/user-attachments/assets/06ca750f-f97f-4f07-a9e8-2f5d5cef06f5" />

<img width="326" alt="스크린샷 2025-04-25 오전 10 34 22" src="https://github.com/user-attachments/assets/b2ee9579-cca9-4bf9-9eb2-9e0f61524865" />

<img width="326" alt="스크린샷 2025-04-25 오전 10 34 26" src="https://github.com/user-attachments/assets/747c24d9-9cd6-4481-bf19-6779d787db1f" />


- 섹션 애니메이션 추가


https://github.com/user-attachments/assets/fa635270-55ce-4818-9270-66d855fdd308

