### PR TITLE
카드 레이아웃

### DIFF
--- a/src/app/result/page.tsx
+++ b/src/app/result/page.tsx
@@ -1,8 +1,24 @@
+import Card from '@/components/common/Card';
+
+const cardData = [
+  { front: 'HTML', back: '하이퍼텍스트 마크업 언어' },
+  { front: 'CSS', back: '스타일 시트' },
+  { front: 'JavaScript', back: '동적인 웹을 만드는 언어' },
+];
 
 export default function Page() {
   return (
-    <div>
-      결과페이지
+    <div className="flex min-h-screen items-center justify-center gap-10">
+      {cardData.map((item, index) => (
+        <Card
+          key={index}
+          containerClassName="h-80 w-48"
+          frontClassName="bg-blue-200 text-black"
+          backClassName="bg-blue-400 text-black"
+          frontText={item.front}
+          backText={item.back}
+        />
+      ))}
     </div>
   );
 }

--- a/src/app/result/page.tsx
+++ b/src/app/result/page.tsx
@@ -1,11 +1,5 @@
 import Card from '@/components/common/Card';
-
-
-const cardData = [
-  { front: 'HTML', back: '하이퍼텍스트 마크업 언어' },
-  { front: 'CSS', back: '스타일 시트' },
-  { front: 'JavaScript', back: '동적인 웹을 만드는 언어' },
-];
+import {cardData} from '@/mock/resultCard';
 
 export default function Page() {
   return (

--- a/src/app/result/page.tsx
+++ b/src/app/result/page.tsx
@@ -1,5 +1,6 @@
 import Card from '@/components/common/Card';
 
+
 const cardData = [
   { front: 'HTML', back: '하이퍼텍스트 마크업 언어' },
   { front: 'CSS', back: '스타일 시트' },

--- a/src/components/common/Card/index.tsx
+++ b/src/components/common/Card/index.tsx
@@ -1,27 +1,35 @@
 'use client';
 
-import { useState } from 'react';
+interface CardProps {
+  frontClassName?: string;
+  backClassName?: string;
+  containerClassName?: string;
+  frontText?: string; 
+  backText?: string;  
+}
 
-export default function Home() {
-  const [isFlipped, setIsFlipped] = useState(false);
-
+export default function Card({
+  frontClassName = '',
+  backClassName = '',
+  containerClassName = '',
+  frontText = '앞면',  
+  backText = '뒷면',   
+}: CardProps) {
   return (
-    <div className="flex min-h-screen items-center justify-center">
-      <div
-        className="cursor-pointer perspective-midrange"
-        onClick={() => setIsFlipped(!isFlipped)}
-      >
+    <div
+      className={`cursor-pointer ${containerClassName}`}
+      style={{ perspective: '1000px' }}
+    >
+      <div className="relative w-full h-full transition-transform duration-700 [transform-style:preserve-3d] hover:rotate-y-180">
         <div
-          className={`relative h-96 w-64 transition-transform duration-700 transform-3d ${
-            isFlipped ? 'rotate-y-180' : ''
-          }`}
+          className={`absolute flex h-full w-full items-center justify-center rounded-xl p-4 shadow-lg backface-hidden ${frontClassName}`}
         >
-          <div className="absolute flex h-full w-full items-center justify-center rounded-xl bg-white p-4 shadow-lg backface-hidden">
-            <div>카드앞면</div>
-          </div>
-          <div className="absolute flex h-full w-full rotate-y-180 items-center justify-center rounded-xl bg-blue-500 p-4 text-white shadow-lg backface-hidden">
-            <div>카드뒷면</div>
-          </div>
+          <div>{frontText}</div> 
+        </div>
+        <div
+          className={`absolute flex h-full w-full items-center justify-center rounded-xl p-4 shadow-lg rotate-y-180 backface-hidden ${backClassName}`}
+        >
+          <div>{backText}</div> 
         </div>
       </div>
     </div>

--- a/src/components/common/Card/index.tsx
+++ b/src/components/common/Card/index.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useState } from 'react';
+
+export default function Home() {
+  const [isFlipped, setIsFlipped] = useState(false);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <div
+        className="cursor-pointer perspective-midrange"
+        onClick={() => setIsFlipped(!isFlipped)}
+      >
+        <div
+          className={`relative h-96 w-64 transition-transform duration-700 transform-3d ${
+            isFlipped ? 'rotate-y-180' : ''
+          }`}
+        >
+          <div className="absolute flex h-full w-full items-center justify-center rounded-xl bg-white p-4 shadow-lg backface-hidden">
+            <div>카드앞면</div>
+          </div>
+          <div className="absolute flex h-full w-full rotate-y-180 items-center justify-center rounded-xl bg-blue-500 p-4 text-white shadow-lg backface-hidden">
+            <div>카드뒷면</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/common/Card/index.tsx
+++ b/src/components/common/Card/index.tsx
@@ -1,19 +1,13 @@
 'use client';
 
-interface CardProps {
-  frontClassName?: string;
-  backClassName?: string;
-  containerClassName?: string;
-  frontText?: string; 
-  backText?: string;  
-}
+import { CardProps } from '@/types/card';
 
 export default function Card({
   frontClassName = '',
   backClassName = '',
   containerClassName = '',
-  frontText = '앞면',  
-  backText = '뒷면',   
+  frontText = '앞면',
+  backText = '뒷면',
 }: CardProps) {
   return (
     <div
@@ -24,12 +18,12 @@ export default function Card({
         <div
           className={`absolute flex h-full w-full items-center justify-center rounded-xl p-4 shadow-lg backface-hidden ${frontClassName}`}
         >
-          <div>{frontText}</div> 
+          <div>{frontText}</div>
         </div>
         <div
           className={`absolute flex h-full w-full items-center justify-center rounded-xl p-4 shadow-lg rotate-y-180 backface-hidden ${backClassName}`}
         >
-          <div>{backText}</div> 
+          <div>{backText}</div>
         </div>
       </div>
     </div>

--- a/src/mock/resultCard.ts
+++ b/src/mock/resultCard.ts
@@ -1,0 +1,5 @@
+export const cardData = [
+  { front: '테스트1', back: '경준이형' },
+  { front: '테스트2', back: '사랑해' },
+  { front: '테스트3', back: '보고싶어' },
+];

--- a/src/types/card.ts
+++ b/src/types/card.ts
@@ -1,0 +1,7 @@
+export interface CardProps {
+  frontClassName?: string;
+  backClassName?: string;
+  containerClassName?: string;
+  frontText?: string;
+  backText?: string;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈(이슈번호와 연동)

close #77 

## 📝작업 내용(작업한 내용을 간략히 설명)

- 카드 컴포넌트를 생성했는데, 상위 컴포넌트에서 사용할 때 clssName으로 커스텀 가능하게 수정했습니다
- 또한, hover시에 rotate 180회전하여 뒷 면이 보이도록 했습니다.
- front Text와 backText를 props로 받아줬습니다.

## 스크린샷
<img width="761" alt="스크린샷 2025-04-29 오전 9 34 53" src="https://github.com/user-attachments/assets/431ce44e-f307-411a-9278-2939da861c87" />

<img width="761" alt="스크린샷 2025-04-29 오전 9 34 56" src="https://github.com/user-attachments/assets/17ff3f6e-c972-43eb-835a-05832bfb9df2" />

